### PR TITLE
hot-module-replacement, se habilita el hmr de manera que se valide lo…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,3 +23,12 @@ function component() {
 }
 
 document.body.appendChild(component());
+
+// Si un modulo cambia (osea un archivo o dependencia) se aceptara el cambio
+// When a change inside print.js is detected we tell webpack to accept the updated module.
+if (module.hot) {
+  module.hot.accept('./print.js', function() {
+    console.log('Accepting the updated printMe module!');
+    printMe();
+  })
+}

--- a/src/print.js
+++ b/src/print.js
@@ -1,3 +1,3 @@
 export default function printMe() {
-  console.log('I get called from print.js!!!');
+  console.log('Updating print.js...')
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,23 +4,27 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 // Hace un clean al directorio del output
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 
+const webpack = require('webpack')
+
 module.exports = {
   entry: {
-    app: './src/index.js',
-    print: './src/print.js'
+    app: './src/index.js'
   },
   // Para mapear los archivos que arrojen errores
   devtool: 'inline-source-map',
   // The webpack-dev-server provides you with a simple web server and the ability to use live reloading.
   // This tells webpack-dev-server to serve the files from the dist directory on localhost:8080.
   devServer: {
-    contentBase: './dist'
+    contentBase: './dist',
+    // Habilitara Hot Module Replacement
+    hot: true
   },
   plugins: [
     new CleanWebpackPlugin(['dist']),
     new HtmlWebpackPlugin({
       title: 'Output Management'
-    })
+    }),
+    new webpack.HotModuleReplacementPlugin()
   ],
   output: {
     filename: '[name].bundle.js',


### PR DESCRIPTION
…s cambios en un modulo

Enabling HMR

This feature is great for productivity. All we need to do is update our webpack-dev-server configuration, and use webpack's built in HMR plugin. We'll also remove the entry point for print.js as it will now be consumed by the index.js module.

    If you took the route of using webpack-dev-middleware instead of webpack-dev-server, please use the webpack-hot-middleware package to enable HMR on your custom server or application. 

webpack.config.js

  const path = require('path');
  const HtmlWebpackPlugin = require('html-webpack-plugin');
+ const webpack = require('webpack');

  module.exports = {
    entry: {
-      app: './src/index.js',
-      print: './src/print.js'
+      app: './src/index.js'
    },
    devtool: 'inline-source-map',
    devServer: {
      contentBase: './dist',
+     hot: true
    },
    plugins: [
      new HtmlWebpackPlugin({
        title: 'Hot Module Replacement'
      }),
+     new webpack.HotModuleReplacementPlugin()
    ],
    output: {
      filename: '[name].bundle.js',
      path: path.resolve(__dirname, 'dist')
    }
  };

You can also use the CLI to modify the webpack-dev-server configuration with the following command: webpack-dev-server --hotOnly.

To get it up and running let's run npm start from the command line.

Now let's update the index.js file so that when a change inside print.js is detected we tell webpack to accept the updated module.

index.js

  import _ from 'lodash';
  import printMe from './print.js';

  function component() {
    var element = document.createElement('div');
    var btn = document.createElement('button');

    element.innerHTML = _.join(['Hello', 'webpack'], ' ');

    btn.innerHTML = 'Click me and check the console!';
    btn.onclick = printMe;

    element.appendChild(btn);

    return element;
  }

  document.body.appendChild(component());
+
+ if (module.hot) {
+   module.hot.accept('./print.js', function() {
+     console.log('Accepting the updated printMe module!');
+     printMe();
+   })
+ }

Start changing the console.log statement in print.js, and you should see the following output in the browser console.

print.js

  export default function printMe() {
-   console.log('I get called from print.js!');
+   console.log('Updating print.js...')
  }
